### PR TITLE
[ 修改首頁header樣式 ] 靈感取自apple產品發表會 最新UI設計 liquid-glass

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -29,8 +29,7 @@ const handleLogout = () => {
   <div>
     <!-- Header：根據路由條件顯示 -->
     <Header v-if="showHeader" />
-
-    <!-- 根據路由決定是否要限制寬度 -->
+    
     <main :class="mainClass">
       <RouterView />
     </main>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,228 +1,71 @@
 <script setup>
-import { ref, onMounted, onUnmounted } from "vue";
-import { RouterLink, RouterView  } from "vue-router";
-import { useUserStore } from "@/stores/user";
-import router from "@/router";
-const store = useUserStore();
+import { ref, onMounted, onUnmounted } from 'vue'
 
+const isDragging = ref(false)
+const startX = ref(0)
+const startY = ref(0)
+const inLightBackground = ref(false)
+const glassRef = ref(null)
 
-const handleLogout = () => {
-  store.logout();
-  alert("已登出");
-  router.push("/login");
-};
+function startDrag(event) {
+  isDragging.value = true
+  startX.value = event.clientX
+  startY.value = event.clientY
+}
 
-// 控制下拉框的顯示與隱藏
-const isDropdownOpen = ref(false);
+function stopDrag() {
+  isDragging.value = false
+}
 
-// 切換下拉框顯示狀態
-const toggleDropdown = () => {
-  isDropdownOpen.value = !isDropdownOpen.value;
-};
+function onDrag(event) {
+  if (!isDragging.value) return
 
-// 點擊其他地方關閉下拉框
-const closeDropdown = (event) => {
-  if (!event.target.closest(".relative")) {
-    isDropdownOpen.value = false;
-  }
-};
+  const dx = event.clientX - startX.value
+  const dy = event.clientY - startY.value
 
-// 在組件掛載時添加全局點擊事件監聽器
+  event.currentTarget.style.transform = `translate(${dx}px, ${dy}px)`
+}
+
+function handleScroll() {
+  const y = window.scrollY
+  // 滑動變色
+  inLightBackground.value = y >= 900 && y < 4000
+}
+
 onMounted(() => {
-  window.addEventListener("click", closeDropdown);
-});
+  window.addEventListener('scroll', handleScroll)
+})
 
-// 組件卸載時移除事件監聽器
 onUnmounted(() => {
-  window.removeEventListener("click", closeDropdown);
-});
+  window.removeEventListener('scroll', handleScroll)
+})
 </script>
 
 <template>
-  <header
-    class="fixed top-0 left-0 w-full h-20 z-50 text-[#515151] bg-white/50 backdrop-blur-sm shadow"
-    style="
-      box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.1),
-        inset -1px -1px 1px rgba(255, 255, 255, 0.35);
-    "
-  >
-    <nav class="flex items-center justify-between px-6 py-4">
-      <!-- 左側 -->
-      <div class="flex items-center">
-        <RouterLink to="/" class="text-2xl italic font-light leading-none">
-          Kizuna
-        </RouterLink>
+  <header class="fixed top-4 left-3 z-50">
+    <div
+      ref="glassRef"
+      class="relative rounded-full bg-white/10 backdrop-blur-lg border border-white/20 shadow-xl overflow-hidden group transition-all duration-300 hover:scale-105 cursor-pointer"
+      @mousedown="startDrag"
+      @mouseup="stopDrag"
+      @mousemove="onDrag"
+    >
+      <!-- 背景光暈 -->
+      <div class="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.3),transparent_70%)] opacity-40 blur-2xl pointer-events-none"></div>
+      <!-- 文字內容，根據背景切換顏色與 hover 效果 -->
+      <div
+        class="p-4 text-xl transition-colors duration-300 group-hover:bg-gradient-to-r from-[rgba(96,165,250,0.3)] to-[rgba(236,72,153,0.3)]
+ hover:transition-all duration-300"
+        :class="inLightBackground ? 'text-gray-800 drop-shadow-[0_0_4px_rgba(0,0,0,0.3)]' : 'text-white drop-shadow-[0_1px_3px_rgba(255,255,255,0.5)]'"
+      >
+        Liquid Glass UI
       </div>
-
-      <!-- 中間 -->
-      <div class="flex justify-center flex-1 space-x-4">
-        <RouterLink
-          to="/match"
-          class="p-4 text-lg leading-none transition hover:text-gray-300"
-        >
-          配對池
-        </RouterLink>
-
-        <RouterLink
-          to="/product"
-          class="p-4 text-lg leading-none transition hover:text-gray-300"
-        >
-          商品列表
-        </RouterLink>
-
-        <RouterLink
-          to="/activities"
-          class="p-4 text-lg leading-none transition hover:text-gray-300"
-          >活動</RouterLink
-        >
-        <RouterLink
-          to="/activities/new"
-          class="p-4 text-lg leading-none transition hover:text-gray-300"
-          >活動表單</RouterLink
-        >
-        <RouterLink
-          to="/activities/edit/:id"
-          class="p-4 text-lg leading-none transition hover:text-gray-300"
-          >活動編輯</RouterLink
-        >
-      </div>
-
-      <!-- 右側 -->
-
-      <!-- 沒有token 請先登入或註冊新帳號 -->
-      <template v-if="!store.accessToken">
-        <RouterLink
-          to="/login"
-          class="p-4 text-lg leading-none transition hover:text-gray-300"
-          >登入</RouterLink
-        >
-        <RouterLink
-          to="/register"
-          class="p-4 text-lg leading-none transition hover:text-gray-300"
-          >註冊</RouterLink
-        >
-        <!-- 聊天室 -->
-        <RouterLink
-          to="/chat"
-          class="p-2 text-lg leading-none transition hover:text-gray-300"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            class="size-7"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M4.804 21.644A6.707 6.707 0 0 0 6 21.75a6.721 6.721 0 0 0 3.583-1.029c.774.182 1.584.279 2.417.279 5.322 0 9.75-3.97 9.75-9 0-5.03-4.428-9-9.75-9s-9.75 3.97-9.75 9c0 2.409 1.025 4.587 2.674 6.192.232.226.277.428.254.543a3.73 3.73 0 0 1-.814 1.686.75.75 0 0 0 .44 1.223ZM8.25 10.875a1.125 1.125 0 1 0 0 2.25 1.125 1.125 0 0 0 0-2.25ZM10.875 12a1.125 1.125 0 1 1 2.25 0 1.125 1.125 0 0 1-2.25 0Zm4.875-1.125a1.125 1.125 0 1 0 0 2.25 1.125 1.125 0 0 0 0-2.25Z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </RouterLink>
-
-        <!-- 購物車 -->
-        <RouterLink
-          to="/cart"
-          class="p-4 text-lg leading-none transition hover:text-gray-300"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            class="size-7"
-          >
-            <path
-              d="M2.25 2.25a.75.75 0 0 0 0 1.5h1.386c.17 0 .318.114.362.278l2.558 9.592a3.752 3.752 0 0 0-2.806 3.63c0 .414.336.75.75.75h15.75a.75.75 0 0 0 0-1.5H5.378A2.25 2.25 0 0 1 7.5 15h11.218a.75.75 0 0 0 .674-.421 60.358 60.358 0 0 0 2.96-7.228.75.75 0 0 0-.525-.965A60.864 60.864 0 0 0 5.68 4.509l-.232-.867A1.875 1.875 0 0 0 3.636 2.25H2.25ZM3.75 20.25a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0ZM16.5 20.25a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0Z"
-            />
-          </svg>
-        </RouterLink>
-      </template>
-
-      <!-- 已登入顯示：帳號名稱 + 頭像選單 -->
-      <div class="flex items-center space-x-4">
-        <!--v-if="store.accessToken" (顯示已登入)-->
-        <div class="relative">
-          <div
-            class="flex items-center justify-center w-12 h-12 text-sm font-bold bg-[#ddedff] rounded-full text-[#7395BA] hover:bg-slate-300"
-            @click="toggleDropdown"
-          ></div>
-          <div
-            v-if="isDropdownOpen"
-            class="absolute right-0 w-40 mt-2 overflow-hidden bg-white border border-gray-200 rounded-lg shadow-lg"
-          >
-            <div
-              class="flex items-center justify-center px-4 py-4 text-gray-500"
-            >
-              目前登入帳號為 :
-              {{ store.username }}
-            </div>
-            <RouterLink
-              to="/edit-profile"
-              class="flex items-center gap-2 px-4 py-4 text-gray-600 border-b border-gray-300 hover:bg-gray-100"
-              @click="isDropdownOpen = false"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-                class="size-6"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"
-                />
-              </svg>
-
-              <span class="whitespace-nowrap">編輯個人檔案</span>
-            </RouterLink>
-            <a
-              href="#"
-              class="flex items-center gap-2 px-4 py-4 text-gray-600 border-b border-gray-300 hover:bg-gray-100"
-              ><svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-                class="size-6"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"
-                />
-              </svg>
-              升級方案</a
-            >
-            <a
-              href="#"
-              class="flex items-center gap-2 px-4 py-4 text-gray-600 border-b border-gray-300 hover:bg-gray-100"
-              @click="handleLogout"
-              ><svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-                class="size-5"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15m-3 0-3-3m0 0 3-3m-3 3H15"
-                />
-              </svg>
-              登出</a
-            >
-          </div>
-        </div>
-      </div>
-    </nav>
+    </div>
   </header>
-  
-
 </template>
 
-<style></style>
+<style scoped>
+.group:hover .glow {
+  opacity: 1;
+}
+</style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,35 +1,32 @@
 <script setup>
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted } from "vue";
+import { useUserStore } from "@/stores/user";
+import router from "@/router";
+import LiquidNavLink from "@/components/LiquidGlass.vue";
+
+const store = useUserStore();
+const handleLogout = () => {
+  store.logout();
+  alert("已登出");
+  router.push("/login");
+};
 
 const isDragging = ref(false)
 const startX = ref(0)
 const startY = ref(0)
-const inLightBackground = ref(false)
-const glassRef = ref(null)
-
-function startDrag(event) {
-  isDragging.value = true
-  startX.value = event.clientX
-  startY.value = event.clientY
-}
-
-function stopDrag() {
-  isDragging.value = false
-}
-
-function onDrag(event) {
-  if (!isDragging.value) return
-
-  const dx = event.clientX - startX.value
-  const dy = event.clientY - startY.value
-
-  event.currentTarget.style.transform = `translate(${dx}px, ${dy}px)`
-}
+const debugY = ref(0)
+const textColorClass = ref("white");
 
 function handleScroll() {
-  const y = window.scrollY
-  // 滑動變色
-  inLightBackground.value = y >= 900 && y < 4000
+  const y = window.scrollY;
+  debugY.value = y;
+  if (y < 900) {
+    textColorClass.value = "white";
+  } else if (y >= 900 && y < 3700) {
+    textColorClass.value = "black";
+  } else {
+    textColorClass.value = "blue";
+  }
 }
 
 onMounted(() => {
@@ -42,27 +39,54 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <header class="fixed top-4 left-3 z-50">
-    <div
-      ref="glassRef"
-      class="relative rounded-full bg-white/10 backdrop-blur-lg border border-white/20 shadow-xl overflow-hidden group transition-all duration-300 hover:scale-105 cursor-pointer"
-      @mousedown="startDrag"
-      @mouseup="stopDrag"
-      @mousemove="onDrag"
-    >
-      <!-- 背景光暈 -->
-      <div class="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.3),transparent_70%)] opacity-40 blur-2xl pointer-events-none"></div>
-      <!-- 文字內容，根據背景切換顏色與 hover 效果 -->
-      <div
-        class="p-4 text-xl transition-colors duration-300 group-hover:bg-gradient-to-r from-[rgba(96,165,250,0.3)] to-[rgba(236,72,153,0.3)]
- hover:transition-all duration-300"
-        :class="inLightBackground ? 'text-gray-800 drop-shadow-[0_0_4px_rgba(0,0,0,0.3)]' : 'text-white drop-shadow-[0_1px_3px_rgba(255,255,255,0.5)]'"
-      >
-        Liquid Glass UI
+  <header class="fixed top-0 left-0 w-full h-20 z-50">
+    <nav class="flex items-center justify-between px-6 py-4">
+      <!-- debug -->
+      <div class="absolute top-20 left-4 text-sm text-white bg-black px-2 py-1 rounded">
+        scrollY in {{ debugY }}: {{ textColorClass }}
       </div>
-    </div>
+      <div class="flex items-center">
+        <LiquidNavLink to="/" :colorMode="textColorClass">Kizuna</LiquidNavLink>
+      </div>
+
+      <div class="flex justify-center flex-1 space-x-4">
+        <LiquidNavLink to="/match" :colorMode="textColorClass">配對池</LiquidNavLink>
+        <LiquidNavLink to="/product" :colorMode="textColorClass">商品列表</LiquidNavLink>
+        <LiquidNavLink to="/activities" :colorMode="textColorClass">活動</LiquidNavLink>
+        <LiquidNavLink to="/activities/new" :colorMode="textColorClass">活動表單</LiquidNavLink>
+        <LiquidNavLink to="/activities/edit/:id" :colorMode="textColorClass">活動編輯</LiquidNavLink>
+      </div>
+
+      <template v-if="!store.accessToken">
+        <LiquidNavLink to="/login" :colorMode="textColorClass">登入</LiquidNavLink>
+        <LiquidNavLink to="/register" :colorMode="textColorClass">註冊</LiquidNavLink>
+        <LiquidNavLink to="/chat">💬</LiquidNavLink>
+        <LiquidNavLink to="/cart">🛒</LiquidNavLink>
+      </template>
+
+      <div class="flex items-center space-x-4">
+        <div class="relative">
+          <div
+            class="flex items-center justify-center w-12 h-12 text-sm font-bold bg-[#ddedff] rounded-full text-[#7395BA] hover:bg-slate-300"
+            @click="toggleDropdown"></div>
+          <div v-if="isDropdownOpen"
+            class="absolute right-0 w-40 mt-2 overflow-hidden bg-white border border-gray-200 rounded-lg shadow-lg">
+            <div class="flex items-center justify-center px-4 py-4 text-gray-500">
+              目前登入帳號為 : {{ store.username }}
+            </div>
+            <LiquidNavLink to="/edit-profile" @click="isDropdownOpen = false">編輯個人檔案</LiquidNavLink>
+            <a href="#"
+              class="flex items-center gap-2 px-4 py-4 text-gray-600 border-b border-gray-300 hover:bg-gray-100">升級方案</a>
+            <a href="#"
+              class="flex items-center gap-2 px-4 py-4 text-gray-600 border-b border-gray-300 hover:bg-gray-100"
+              @click="handleLogout">登出</a>
+          </div>
+        </div>
+      </div>
+    </nav>
   </header>
 </template>
+
 
 <style scoped>
 .group:hover .glow {

--- a/src/components/LiquidGlass.vue
+++ b/src/components/LiquidGlass.vue
@@ -1,0 +1,26 @@
+<script setup>
+defineProps({
+  to: String,
+  colorMode: {
+    type: String,
+    default: "white",
+  },
+});
+</script>
+
+<template>
+  <RouterLink
+    :to="to"
+    class="group relative overflow-hidden rounded-full px-6 py-2 text-lg transition-all duration-300 backdrop-blur-xl bg-white/10 border border-white/20 shadow-xl hover:scale-105 hover:brightness-110"
+      :class="{
+      'text-white drop-shadow-[0_1px_3px_rgba(255,255,255,0.5)]': colorMode === 'white',
+      'text-gray-800 drop-shadow-[0_0_4px_rgba(0,0,0,0.3)]': colorMode === 'black',
+      'text-[#2F4858] drop-shadow-[0_0_6px_rgba(0,128,255,0.4)]': colorMode === 'blue',
+    }"
+  >
+    <span class="relative z-10"><slot /></span>
+    <span
+      class="absolute inset-0 z-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-r from-[rgba(96,165,250,0.3)] to-[rgba(236,72,153,0.3)] blur-md"
+    ></span>
+  </RouterLink>
+</template>


### PR DESCRIPTION
### DEMO影片
https://youtu.be/RCsq1g6Mo80

### 本次改動
- 將原本的 <header> 改成 液態玻璃 材質 並設定
   - 字體光暈效果
   - 隨滑動高度字體變色  `window.scrollY`
   - 模糊效果( 實現玻璃感 ) `backdrop-blur-md`
   - `hover`時會變成淡化霓虹色

### 主要修改文件
- `Header.vue`
- `LiquidGlass.vue`


### 下一步
- 把 `<header>` 的欄位全部加回去
- 其他頁面預設的字體顏色改成黑色