### PR TITLE
[ 增加後台商品頁面 ] 可從前端修正各商品庫存數量

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -14,6 +14,7 @@ import EditProfileView from "@/views/EditProfileView.vue";
 import PaymentView from '@/views/PaymentView.vue';
 import BlessingView from "@/views/BlessingView.vue";
 import GiftCheckoutView from "@/views/GiftCheckoutView.vue";
+import ProductAdminView from "@/views/ProductAdminView.vue";
 import { useUserStore } from "@/stores/user.js";
 
 const router = createRouter({
@@ -107,7 +108,12 @@ const router = createRouter({
       path: '/payment',
       name: 'Payment',
       component: PaymentView
-    }
+    },
+    {
+      path: "/super/products/inventory",
+      name: "ProductAdmin",
+      component: ProductAdminView,
+    },
   ],
 });
 

--- a/src/views/ProductAdminView.vue
+++ b/src/views/ProductAdminView.vue
@@ -1,0 +1,67 @@
+<script setup>
+import { ref, onMounted } from "vue";
+import axios from "@/api/axios";
+
+const products = ref([]);
+
+onMounted(async () => {
+  await fetchProducts();
+});
+
+const fetchProducts = async () => {
+  const res = await axios.get("/products");
+  products.value = res.data;
+};
+
+const updateInventory = async (productId, newInventory) => {
+  console.log("更新商品 ID:", productId);
+  console.log("新庫存數量:", newInventory);
+  try {
+    await axios.put(`admin/products/${productId}/inventory`, {
+      inventory: Number(newInventory),
+    });
+    alert("更新成功");
+    await fetchProducts(); // 重新載入資料
+  } catch (err) {
+    console.error("更新庫存失敗", err);
+    alert("更新失敗，請稍後再試");
+  }
+};
+</script>
+
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">商品庫存總覽</h1>
+    <table class="w-full table-auto border">
+      <thead>
+        <tr class="bg-gray-100">
+          <th class="p-2 border">商品名稱</th>
+          <th class="p-2 border">價格</th>
+          <th class="p-2 border">剩餘庫存</th>
+          <th class="p-2 border">操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="p in products" :key="p.id">
+          <td class="p-2 border">{{ p.name }}</td>
+          <td class="p-2 border">{{ p.price }}</td>
+          <td class="p-2 border">
+            <input
+              v-model.number="p.inventory"
+              type="number"
+              class="w-24 border p-1"
+            />
+          </td>
+          <td class="p-2 border">
+            <button
+              class="bg-blue-500 text-white px-3 py-1 rounded"
+              @click="updateInventory(p.id, p.inventory)"
+            >
+              更新庫存
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>


### PR DESCRIPTION
- 可進入以下網址查看目前各商品庫存數量
`http://localhost:5173/super/products/inventory`
( 為了節省開發時間 感覺可以把 super 用一串很難猜的數字取代 再加入環境變數中 這樣其他人就很難進入我們的這個頁面？？)
路由路徑設定在 `index.js` 中
- 在這個網址中 你可以更新商品庫存
   - 會觸發 `updateInventory()` 這個 func
      - 他會打 PUT API 到後端更新資料庫庫存後
      - 再刷新頁面呈現最新的結果
- 後面預計做
- [ ] 當 linepay訂單成功後 依照使用者買的商品更新資料庫庫存