### PR TITLE
[ 編輯個人檔案區｜照片區 ] 新增使用者上傳、修改大頭照功能 

### DIFF
--- a/src/api/photos.js
+++ b/src/api/photos.js
@@ -1,11 +1,23 @@
 import axios from "@/api/axios";
 
+// 取我的所有照片
 export const getPhotos = async () => {
   try {
-    const res = await axios.get("/photos");
+    const res = await axios.get("/photos/me");
     return res.data;
   } catch (err) {
     console.error("getPhotos 錯誤:", err);
+    throw err;
+  }
+};
+
+// 取他人指定的公開照
+export const getPublicPhotos = async () => {
+  try {
+    const res = await axios.get("/users/photos/:userId");
+    return res.data;
+  } catch (err) {
+    console.error("getPublicPhotos 錯誤:", err);
     throw err;
   }
 };
@@ -14,7 +26,7 @@ export const uploadPhoto = async (file) => {
   try {
     const formData = new FormData();
     formData.append("image", file);
-    const res = await axios.post("/photos", formData, {
+    const res = await axios.post("/photos/me", formData, {
       headers: { "Content-Type": "multipart/form-data" },
     });
     return res.data;
@@ -26,9 +38,22 @@ export const uploadPhoto = async (file) => {
 
 export const deletePhoto = async (key) => {
   try {
-    await axios.delete(`/photos/${key}`);
+    await axios.delete(`/photos/me/${key}`);
   } catch (err) {
     console.error("deletePhoto 錯誤:", err);
+    throw err;
+  }
+};
+
+// 更換大頭照
+export const changeAvatar = async (imageKey) => {
+  try {
+    await axios.patch("/photos/me/avatar", {
+      key: imageKey,
+    });
+    alert(" 大頭貼已更新 ");
+  } catch (err) {
+    console.error("changeAvatar 錯誤", err);
     throw err;
   }
 };

--- a/src/components/ProfilePhotos.vue
+++ b/src/components/ProfilePhotos.vue
@@ -1,16 +1,85 @@
 <!-- 照片邏輯 -->
 <script setup>
 import { ref, onMounted, defineExpose } from "vue";
-import { getPhotos, uploadPhoto, deletePhoto } from "@/api/photos";
+import {
+  getPhotos,
+  uploadPhoto,
+  deletePhoto,
+  changeAvatar,
+} from "@/api/photos";
 
-const photoList = ref([
-  { file: null, preview: "" },
-  { file: null, preview: "" },
-  { file: null, preview: "" },
-  { file: null, preview: "" },
-  { file: null, preview: "" },
-  { file: null, preview: "" },
-]);
+// 在refreshPhotos() 裡正式建立 6 格
+const photoList = ref([]);
+
+const myAvatar = ref(null);
+const showModal = ref(false);
+const fileInputRef = ref(null);
+
+const chooseAvatar = () => (showModal.value = true);
+const closeModal = () => (showModal.value = false);
+
+const triggerAvatarInput = () => {
+  if (fileInputRef.value) {
+    fileInputRef.value.click();
+  }
+};
+
+const refreshPhotos = async () => {
+  try {
+    const images = await getPhotos();
+
+    // 清空資料
+    myAvatar.value = null;
+    photoList.value = Array(6)
+      .fill()
+      .map(() => ({
+        file: null,
+        preview: "",
+        key: null,
+      }));
+
+    // 分類圖片
+    let photoIndex = 0;
+    images.forEach((item) => {
+      if (item.is_avatar) {
+        myAvatar.value = {
+          preview: item.image_url,
+          key: item.image_key,
+        };
+      } else if (photoIndex < photoList.value.length) {
+        photoList.value[photoIndex].preview = item.image_url;
+        photoList.value[photoIndex].key = item.image_key;
+        photoIndex++;
+      }
+    });
+  } catch (err) {
+    console.error("載入圖片失敗", err);
+  }
+};
+
+const handleAvatarUpload = async (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+
+  try {
+    // 上傳圖片到 S3，取得 URL 和 key
+    const data = await uploadPhoto(file); // 上傳API
+
+    // 設為大頭貼
+    await changeAvatar(data.key); // 換頭貼 API
+    // 直接重抓所有圖片
+    await refreshPhotos();
+
+    // 關閉 modal 並提示
+    closeModal();
+    alert("大頭貼設定成功");
+  } catch (err) {
+    console.error("大頭貼上傳失敗", err);
+    alert("大頭貼上傳失敗，請重試");
+  } finally {
+    e.target.value = ""; // 清空 input 讓使用者可重傳同一張
+  }
+};
 
 const handleFileChange = (event, index) => {
   const file = event.target.files[0];
@@ -37,9 +106,9 @@ const removePhoto = async (index) => {
     photoList.value[index].file = null;
     photoList.value[index].preview = "";
     photoList.value[index].key = "";
-    console.log("✅ 圖片刪除成功");
+    console.log("圖片刪除成功");
   } catch (err) {
-    console.error("❌ 圖片刪除失敗", err);
+    console.error("圖片刪除失敗", err);
   }
 };
 
@@ -74,8 +143,8 @@ const uploadAll = async () => {
 
   try {
     await Promise.all(uploadPromises);
-    alert("✅ 所有已選圖片都已上傳完成");
-    return uploadedResults; // 回傳上傳成功的結果
+    alert("所有已選圖片都已上傳完成");
+    return uploadedResults;
   } catch (err) {
     console.error("上傳過程發生錯誤", err);
   }
@@ -84,31 +153,94 @@ const uploadAll = async () => {
 // 讓外部元件可以呼叫 uploadAll，editProfileView.view 有呼叫
 defineExpose({ uploadAll });
 
-onMounted(async () => {
-  try {
-    // const res = await axios.get("http://localhost:3000/api/photos");
-    // const images = res.data;
-    const images = await getPhotos();
-    images.forEach((item, index) => {
-      if (index < photoList.value.length) {
-        photoList.value[index].preview = item.image_url;
-        photoList.value[index].key = item.image_key;
-      }
-    });
-  } catch (err) {
-    console.error("圖片載入失敗", err);
-  }
-});
+onMounted(refreshPhotos);
 </script>
 
 <template>
-  <h1 class="mb-6 text-2xl font-bold text-center text-darkblue">上傳照片</h1>
+  <!-- 大頭照圓形區塊 -->
+  <div class="flex flex-col items-center my-5">
+    <h2 class="mb-6 text-2xl font-bold text-center text-darkblue">
+      上傳大頭照
+    </h2>
+
+    <div
+      class="relative flex items-center justify-center w-48 h-48 overflow-hidden bg-gray-100 border-8 border-white rounded-full shadow-xl cursor-pointer"
+      @click="chooseAvatar"
+    >
+      <img
+        v-if="myAvatar"
+        :src="myAvatar.preview"
+        class="object-cover w-full h-full"
+      />
+      <div
+        v-else
+        class="flex items-center justify-center w-full h-full text-xl text-gray-400"
+      >
+        尚無大頭貼
+      </div>
+    </div>
+  </div>
+
+  <!-- 彈窗 -->
+  <div
+    v-if="showModal"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+    @click.self="closeModal"
+  >
+    <div class="flex justify-center mb-6">
+      <div
+        class="relative flex flex-col items-center justify-center p-6 bg-white w-72 h-72 cursor-pointer rounded-[2rem] border border-transparent shadow-2xl bg-gradient-to-br from-white to-gray-50 ring-1 ring-gray-300 ring-opacity-40 hover:shadow-3xl transition-shadow duration-300"
+        @click="triggerAvatarInput"
+      >
+        <!-- 右上角簡單的 ✕ 按鈕 -->
+        <button
+          @click.stop="closeModal"
+          aria-label="Close modal"
+          class="absolute text-2xl font-semibold text-gray-500 transition top-4 right-4 hover:text-gray-800"
+        >
+          ✕
+        </button>
+
+        <!-- 中央上傳icon (放大版) -->
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="w-24 h-24 mb-4 text-secondary"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
+          />
+        </svg>
+
+        <p class="font-medium text-gray-600 select-none">點擊上傳大頭貼</p>
+
+        <!-- 隱藏檔案輸入 -->
+        <input
+          type="file"
+          accept="image/*"
+          ref="fileInputRef"
+          class="hidden"
+          @change="handleAvatarUpload"
+        />
+      </div>
+    </div>
+  </div>
+
+  <!-- 照片上傳區 -->
+
+  <h2 class="mb-6 text-2xl font-bold text-center text-darkblue">上傳照片</h2>
   <div class="grid grid-cols-3 gap-4">
     <div
       v-for="(img, index) in photoList"
       :key="index"
       class="relative flex items-center justify-center overflow-hidden border border-dashed cursor-pointer rounded-xl aspect-square"
     >
+      <!-- 預覽照片 -->
       <input
         type="file"
         class="absolute inset-0 opacity-0 cursor-pointer"
@@ -122,6 +254,7 @@ onMounted(async () => {
         class="object-cover w-full h-full"
       />
 
+      <!-- 刪除按鈕 -->
       <button
         v-if="img.preview"
         @click.stop="removePhoto(index)"


### PR DESCRIPTION
#45  

不好意思la 
因為我落後最新的dev太驚人的數字
所以只好開始拆分檔案、拆branch...分批更新上來
這支PR比較單純一點所以先推 
api 的部分我有確定可以打進資料庫、大頭照皆可正常顯示
-----
1. 主要有修改 photosTable 欄位 (後端待上傳)
2. 新增API ⇨顯示查看使用者大頭照、修改大頭照
3. 流程：
**呼叫` /photos/me/avatar` API `setMyAvatar` 發送PATCH請求
後端把所有 is_avatar 清掉，設定新的圖片
前端也更新 photoList，確保畫面顯示一致**
-----
相關畫面與備註：
<img width="736" alt="image" src="https://github.com/user-attachments/assets/7e98dfcd-2fe0-4c59-ab96-6abd030b70b4" />

<img width="450" alt="image" src="https://github.com/user-attachments/assets/01a259f5-a1fb-4dbf-802d-c46f40ef8e3b" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/445cd623-ad32-4422-8563-55fa1faefca4" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/9b8b196c-270f-4489-9db6-23da0a7d9948" />
