### PR TITLE
將 alert 替換為 vue-toastification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "swiper": "^11.2.8",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0",
+        "vue-toastification": "^2.0.0-rc.5",
         "vue3-lottie": "^3.3.1"
       },
       "devDependencies": {
@@ -6230,6 +6231,15 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
+    },
+    "node_modules/vue-toastification": {
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-2.0.0-rc.5.tgz",
+      "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.2"
+      }
     },
     "node_modules/vue3-lottie": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "swiper": "^11.2.8",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",
+    "vue-toastification": "^2.0.0-rc.5",
     "vue3-lottie": "^3.3.1"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,8 @@ import { useUserStore } from "./stores/user";
 import router from "./router";
 import Header from "./components/Header.vue";
 import { computed } from "vue";
+import { useToast } from 'vue-toastification'
+const toast = useToast()
 
 const store = useUserStore();
 // 拿到當前路由
@@ -20,7 +22,7 @@ const mainClass = computed(() => {
 
 const handleLogout = () => {
   store.logout();
-  alert("已登出");
+  toast("已登出");
   router.push("/login");
 };
 </script>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -5,12 +5,15 @@ import { useRoute } from "vue-router";
 import router from "@/router";
 import LiquidNavLink from "@/components/LiquidGlass.vue";
 import { useCartStore } from '@/stores/cart.js';
+import { useToast } from 'vue-toastification'
+const toast = useToast()
+
 const cartStore = useCartStore();
 const route = useRoute();
 const store = useUserStore();
 const handleLogout = () => {
   store.logout();
-  alert("已登出");
+  toast("已登出");
   router.push("/login");
 };
 

--- a/src/config/toast.js
+++ b/src/config/toast.js
@@ -1,0 +1,22 @@
+const options = {
+  // 基本設定
+  position: 'top-center',     // 顯示位置
+  timeout: 3000,              // 3秒後自動消失
+  closeOnClick: true,         // 點擊可關閉
+  pauseOnHover: true,         // 滑鼠懸停時暫停
+  hideProgressBar: false,     // 顯示進度條
+  icon: true,                 // 顯示圖示
+  transition: "Vue-Toastification__bounce",  // 彈跳動畫
+  maxToasts: 20,
+  // 各類型專用設定
+  toastDefaults: {
+    success: {
+      timeout: 3000,
+    },
+    error: {
+      timeout: 5000, //error的設久一點
+    },
+  }
+}
+
+export { options }

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,9 @@ import "./assets/main.css";
 
 import { createApp } from "vue";
 import { createPinia } from "pinia";
+import Toast from "vue-toastification";
+import 'vue-toastification/dist/index.css'
+import { options } from './config/toast.js'
 
 import App from "./App.vue";
 import router from "./router";
@@ -11,5 +14,6 @@ const app = createApp(App);
 
 app.use(createPinia());
 app.use(router);
+app.use(Toast, options)
 
 app.mount("#app");

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -3,6 +3,8 @@ import { onMounted, ref } from "vue";
 import { useUserStore } from "../stores/user";
 import { Mail, Lock } from "lucide-vue-next";
 import { useRouter } from "vue-router";
+import { useToast } from 'vue-toastification'
+const toast = useToast()
 
 const router = useRouter();
 const store = useUserStore();
@@ -14,17 +16,17 @@ const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 const handleLogin = async () => {
   // 修改：使用 email 和 password 而不是 store.username, store.password
   if (!email.value || !password.value) {
-    alert("請輸入帳號和密碼");
+    toast.error("請輸入帳號和密碼");
     return;
   }
   try {
     await store.login(email.value, password.value);
-    alert("登入成功，歡迎回來！");
+    toast("登入成功，歡迎回來！");
   } catch (error) {
     console.error("登入失敗", error);
     const msg = error.response?.data?.message || "伺服器無回應";
     const reason = error.response?.data?.reason || error.message;
-    alert(`登入失敗\n原因：${msg}:${reason}`);
+    toast.error(`登入失敗\n原因：${msg}:${reason}`);
   }
 };
 
@@ -75,16 +77,16 @@ const handleGoogleResponse = async (res) => {
 
   const idToken = res.credential;
   if (!idToken) {
-    alert("登入失敗 無效的 Google 憑證");
+    toast("登入失敗 無效的 Google 憑證");
     return;
   }
   try {
     await store.loginWithGoogle(idToken);
-    alert("Google 登入成功！");
+    toast("Google 登入成功！");
     router.push("/");
   } catch (err) {
     console.error("Google 登入錯誤", err);
-    alert("Google 登入失敗，請稍後再試");
+    toast("Google 登入失敗，請稍後再試");
   }
 };
 </script>


### PR DESCRIPTION
原 PR：#11，因為與最新 dev 差異太大，導致衝突過多，因此重開此 PR。

- 新增 vue-toastification 套件並完成全域設定
- 建立 config/toast.js 統一管理 toast 設定
- 將登入頁面的通知從 alert 改為 toast（示範範例）

App.vue、main.js、基本設定都好了，在**config/toast.js**
只要在元件中導入：
```
import { useToast } from 'vue-toastification'
const toast = useToast()
```
並在alert的地方改成toast就有預設的樣式
toast('訊息')           // 寫好的預設樣式(顯示在中間 藍色的)
**或是直接用官方的**
toast.success('成功訊息')    // 綠色成功通知
toast.error('錯誤訊息')      // 紅色錯誤通知  
toast.warning('警告訊息')    // 橘色警告通知
toast.info('一般訊息')       // 藍色資訊通知


https://github.com/user-attachments/assets/9624ebd6-fa00-44b1-8e2d-000500939c2b


進階：如果有想要自定義的就配CSS
位置選項
'top-right' | 'top-center' | 'top-left' | 'bottom-right' | 'bottom-center' | 'bottom-left'
常用參數
timeout - 顯示時間（毫秒）
position - 顯示位置
hideProgressBar - 隱藏進度條
closeOnClick - 點擊關閉
toastClassName - 自訂 CSS class

舉例：
```
元件中
const showMyCustomNotification = () => {
  toast.info('這是我的客製化通知', {
    toastClassName: 'pink-notification',
    timeout: 6000,
    position: 'bottom-center'
  })
}

<style scoped>
/* 只影響這個元件 */
.pink-notification {
  background: linear-gradient(135deg, #ec4899, #be185d) !important;
  color: white !important;
  border-radius: 20px !important;
  font-weight: bold !important;
}
</style>
```