### PR TITLE
[ Bugfix 上傳大頭照 ] 上傳大頭照失敗、sequence改穩一點

### DIFF
--- a/src/api/photos.js
+++ b/src/api/photos.js
@@ -1,6 +1,6 @@
 import axios from "@/api/axios";
-import { useToast } from 'vue-toastification'
-const toast = useToast()
+import { useToast } from "vue-toastification";
+const toast = useToast();
 
 // 取我的所有照片
 export const getPhotos = async () => {
@@ -24,18 +24,14 @@ export const getPublicPhotos = async () => {
   }
 };
 
-export const uploadPhoto = async (file, sequence = null) => {
+// 只拿來上傳生活照（含 sequence）
+export const uploadPhoto = async (file, sequence) => {
   try {
     const formData = new FormData();
     formData.append("image", file);
+    formData.append("sequence", sequence);
 
-    if (sequence !== null) {
-      formData.append("sequence", sequence);
-    }
-
-    const res = await axios.post("/photos/me", formData, {
-      headers: { "Content-Type": "multipart/form-data" },
-    });
+    const res = await axios.post("/photos/me", formData);
     return res.data;
   } catch (err) {
     console.error("uploadPhoto 錯誤:", err);


### PR DESCRIPTION
#119 
先前的修改方式會導致avatar被判定成 sequence: null  被阻擋上傳
但同時又不希望單獨由後端決定sequence，導致的問題就是因為實際上傳的時間不同步 得到的 sequence值會大亂

現在由前端明確決定每張照片的 sequence 值
所以後端，不需猜測、不需排序
無論使用者上傳幾張、順序如何、是否同時操作，都不會亂掉
後端只處理資料存儲，不主動賦值  ⇨ `sequence: Number(req.body.sequence) // 前端傳多少就存多少`


前端使用生活照的方法：`uploadPhoto(file, sequence)`
- 因為一定會傳 sequence（由 uploadAll() 裡的 index + 1 控制）
- 且用於生活照，自動編排 1～6
- 所以沒有被拿來上傳大頭貼 → 不會有混用管理問題

⇨大頭照不會被誤設順序

資料庫正確傳入：
<img width="769" alt="Image" src="https://github.com/user-attachments/assets/e61f4abe-18b3-4fd7-8bfe-773fd57dfc64" />

注意：
<img width="986" alt="Image" src="https://github.com/user-attachments/assets/cb63cac5-67a7-4dd4-a917-61939ff2f738" />