### PR TITLE
[ 引導篩選小卡頁面 ⇨  配對滑滑 ] 頁面串接

### DIFF
--- a/src/components/MatchSetupCard.vue
+++ b/src/components/MatchSetupCard.vue
@@ -1,24 +1,62 @@
 <script setup>
+import { ref, watch } from "vue";
+
 const props = defineProps({
   title: String,
   options: Array,
-  modelValue: [Array, String], // 可支援單選或多選
+  modelValue: [Array, String, Number],
   multiple: Boolean,
+  type: String, // 如果是 'range' 則顯示輸入框
 });
 
-const emit = defineEmits(["update:modelValue"]);
-// const { multiple, modelValue } = toRefs(props);
-// 不要用 toRefs 解構 modelValue，否則失去 reactivity
+console.log("🔍 props.title", props.title);
+console.log("🔍 props.options", props.options);
+console.log("🔍 props.modelValue", props.modelValue);
+console.log("🔍 props.multiple", props.multiple);
+console.log("🔍 props.type", props.type);
 
-const toggle = (option) => {
-  if (props.multiple) {
-    const arr = Array.isArray(props.modelValue) ? [...props.modelValue] : [];
-    const exists = arr.includes(option);
-    const updated = exists ? arr.filter((i) => i !== option) : [...arr, option];
-    emit("update:modelValue", updated);
-  } else {
-    emit("update:modelValue", option);
+const emit = defineEmits(["update:modelValue"]);
+
+// 初始化選取值
+const selectedValue = ref(props.modelValue);
+
+// 雙向同步：父傳子
+watch(
+  () => props.modelValue,
+  (val) => {
+    selectedValue.value = val;
   }
+);
+
+console.log("🚀 初始 selectedValue:", selectedValue.value);
+
+// 雙向同步：子傳父
+watch(selectedValue, (val) => {
+  console.log("📤 子元件 emit 回父層:", val);
+  emit("update:modelValue", val);
+});
+
+// 切換選項
+const toggle = (option) => {
+  console.log("🟡 toggle 被點了，option:", option);
+  const optionId = option.id ?? option;
+  console.log("🟠 解析出來的 optionId:", optionId);
+  console.log("🟣 當前 selectedValue.value:", selectedValue.value);
+
+  if (props.multiple) {
+    const arr = Array.isArray(selectedValue.value)
+      ? [...selectedValue.value]
+      : [];
+    const exists = arr.includes(optionId);
+    console.log("🔵 是否已存在:", exists);
+    selectedValue.value = exists
+      ? arr.filter((i) => i !== optionId)
+      : [...arr, optionId];
+  } else {
+    selectedValue.value = optionId;
+  }
+
+  console.log("🟢 更新後 selectedValue.value:", selectedValue.value);
 };
 </script>
 
@@ -26,25 +64,50 @@ const toggle = (option) => {
   <div class="mx-auto my-4 card">
     <div class="flex flex-col items-center justify-center p-6 card-info">
       <h2 class="mb-4 text-xl title">{{ title }}</h2>
+
       <div class="flex flex-wrap justify-center gap-2">
         <button
           v-for="option in options"
-          :key="option"
+          :key="option.id ?? option"
+          @click="toggle(option)"
           :class="[
             'w-[140px] px-4 py-2 rounded-full border transition duration-150 ease-in-out',
             {
               'bg-gray-300 text-black': multiple
-                ? Array.isArray(modelValue) && modelValue.includes(option)
-                : modelValue === option,
+                ? Array.isArray(modelValue) && modelValue.includes(option.id)
+                : modelValue === option.id,
               'bg-white text-gray-800': multiple
-                ? !(Array.isArray(modelValue) && modelValue.includes(option))
-                : modelValue !== option,
+                ? !(Array.isArray(modelValue) && modelValue.includes(option.id))
+                : modelValue !== option.id,
             },
           ]"
-          @click="toggle(option)"
         >
-          {{ option }}
+          {{ option.name ?? option }}
         </button>
+      </div>
+
+      <div v-if="type === 'range'" class="mt-4 flex gap-4">
+        <label>
+          最小年齡：
+          <input
+            type="number"
+            min="18"
+            max="70"
+            v-model.number="(selectedValue.value ||= [18, 35])[0]"
+            class="border px-2 py-1 rounded"
+          />
+        </label>
+
+        <label>
+          最大年齡：
+          <input
+            type="number"
+            min="18"
+            max="70"
+            v-model.number="(selectedValue.value ||= [18, 35])[1]"
+            class="border px-2 py-1 rounded"
+          />
+        </label>
       </div>
     </div>
   </div>

--- a/src/components/MatchedDoneModal.vue
+++ b/src/components/MatchedDoneModal.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { useRouter } from "vue-router";
 import { useSendFriendMsg } from "@/api/useMatches.js";
+
 const router = useRouter();
 const { sendFriendMsg } = useSendFriendMsg();
 
@@ -20,7 +21,7 @@ const goToChatRoom = async () => {
   try {
     await sendFriendMsg(props.targetProfile.userId); // 建立好友
 
-    router.push("/chat"); // 跳到聊天室頁面（它會自動載入第一個 room）
+    router.push("/chat"); // 跳到聊天室頁面
   } catch (err) {
     console.error("建立好友關係失敗", err);
     alert("無法進入聊天室，請稍後再試");

--- a/src/components/MatchedDoneModal.vue
+++ b/src/components/MatchedDoneModal.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { useRouter } from "vue-router";
 import { useSendFriendMsg } from "@/api/useMatches.js";
-
 const router = useRouter();
 const { sendFriendMsg } = useSendFriendMsg();
 

--- a/src/views/EditProfileView.vue
+++ b/src/views/EditProfileView.vue
@@ -108,7 +108,7 @@ const handleUpload = async () => {
     // 等待圖片全部上傳
     await profilePhotosRef.value?.uploadAll();
     alert("圖片上傳完成");
-    router.push("/match");
+    router.push("/match/setup");
   } catch (err) {
     console.error(" 上傳失敗", err);
     alert("圖片上傳失敗");

--- a/src/views/MatchSetupView.vue
+++ b/src/views/MatchSetupView.vue
@@ -1,53 +1,81 @@
 <script setup>
 import { ref } from "vue";
-// import { useRouter } from "vue-router";
+import { useRouter } from "vue-router";
 import MatchSetupCard from "@/components/MatchSetupCard.vue";
-// import axios from "@/api/axios";
+import axios from "@/api/axios";
 
-// const router = useRouter();
+const router = useRouter();
 // const userId = localStorage.getItem("userId");
+
+//  統一物件陣列
+const interestsOptions = [
+  { id: 1, name: "音樂" },
+  { id: 2, name: "藝術與手作" },
+  { id: 3, name: "旅遊" },
+  { id: 4, name: "美食" },
+  { id: 5, name: "運動與健身" },
+  { id: 6, name: "閱讀" },
+  { id: 7, name: "遊戲" },
+  { id: 8, name: "寵物與動物" },
+  { id: 9, name: "攝影" },
+  { id: 10, name: "電影與影集" },
+];
 
 const steps = [
   {
     title: "挑幾個你感興趣的選項",
     key: "interests",
-    options: [
-      "音樂",
-      "藝術與手作",
-      "旅遊",
-      "美食",
-      "運動與健身",
-      "閱讀",
-      "遊戲",
-      "寵物與動物",
-      "攝影",
-      "電影與影集",
-    ],
+    options: interestsOptions,
     multiple: true,
   },
   {
     title: "你的音樂靈魂是什麼？",
     key: "musicMatch",
-    options: ["流行音樂", "搖滾", "爵士", "古典音樂", "K-pop", "嘻哈", "R&B"],
+    options: [
+      { id: "pop", name: "流行音樂" },
+      { id: "rock", name: "搖滾" },
+      { id: "jazz", name: "爵士" },
+      { id: "classical", name: "古典音樂" },
+      { id: "kpop", name: "K-pop" },
+      { id: "hiphop", name: "嘻哈" },
+      { id: "rnb", name: "R&B" },
+    ],
     multiple: false,
   },
   {
     title: "你是派對動物還是獨處高手？",
     key: "introvertOrExtrovert",
-    options: ["內向", "外向"],
+    options: [
+      { id: "introvert", name: "內向" },
+      { id: "extrovert", name: "外向" },
+    ],
     multiple: false,
   },
   {
     title: "你心中的萌寵是？",
     key: "pet",
-    options: ["貓", "狗", "爬蟲類", "鳥類", "兔子"],
+    options: [
+      { id: "cat", name: "貓" },
+      { id: "dog", name: "狗" },
+      { id: "reptile", name: "爬蟲類" },
+      { id: "bird", name: "鳥類" },
+      { id: "rabbit", name: "兔子" },
+    ],
     multiple: false,
   },
   {
     title: "你是早鳥還是夜貓子？",
     key: "wakeUpTime",
-    options: ["早睡早起", "夜貓子"],
+    options: [
+      { id: "earlyBird", name: "早睡早起" },
+      { id: "nightOwl", name: "夜貓子" },
+    ],
     multiple: false,
+  },
+  {
+    title: "你希望對方的年齡介於？",
+    key: "ageRange",
+    type: "range",
   },
 ];
 
@@ -58,35 +86,47 @@ const form = ref({
   introvertOrExtrovert: "",
   pet: "",
   wakeUpTime: "",
+  ageRange: [18, 35], // 年齡區間 [最小, 最大]
 });
 
 const nextStep = () => {
   if (step.value < steps.length - 1) step.value++;
-  // else handleSubmit();
+  else submitHandler();
 };
 
-// const handleSubmit = async () => {
-//   try {
-//     await axios.post("/api/user-interests", {
-//       userId,
-//       interestIds: form.value.interests,
-//     });
-//     await axios.post("/api/user-preferences", {
-//       userId,
-//       musicMatch: form.value.musicMatch,
-//       introvertOrExtrovert: form.value.introvertOrExtrovert,
-//       pet: form.value.pet,
-//       wakeUpTime: form.value.wakeUpTime,
-//       ageMin: 20,
-//       ageMax: 40,
-//     });
-//     alert("設定完成，進入配對池！");
-//     router.push("/matching-pool");
-//   } catch (err) {
-//     alert("儲存失敗！");
-//     console.error(err);
-//   }
-// };
+const submitHandler = async () => {
+  try {
+    console.log("📝 送出前 form 資料：", form);
+
+    const [ageMin, ageMax] = form.value.ageRange.sort((a, b) => a - b);
+
+    await axios.post("/user-filter/interests", {
+      interestIds: form.value.interests,
+    });
+
+    await axios.post("/user-filter/preference", {
+      musicMatch: form.value.musicMatch,
+      introvertOrExtrovert: form.value.introvertOrExtrovert,
+      pet: form.value.pet,
+      wakeUpTime: form.value.wakeUpTime,
+      ageMin,
+      ageMax,
+    });
+    console.log("🐛 各欄位值：", {
+      interests: form.value.interests,
+      musicMatch: form.value.musicMatch,
+      introvertOrExtrovert: form.value.introvertOrExtrovert,
+      pet: form.value.pet,
+      wakeUpTime: form.value.wakeUpTime,
+      ageRange: form.value.ageRange,
+    });
+    alert("設定完成，開始配對");
+    router.push("/match");
+  } catch (err) {
+    alert("儲存失敗！");
+    console.error(err);
+  }
+};
 </script>
 
 <template>
@@ -105,12 +145,13 @@ const nextStep = () => {
         :title="steps[step].title"
         :options="steps[step].options"
         :multiple="steps[step].multiple"
+        :type="steps[step].type"
       />
     </TransitionGroup>
 
     <button
       class="mt-6 px-8 py-3 rounded-full font-bold tracking-wide text-[#a5c1e7] border-[3px] border-[#a5c1e7] bg-white transition-all duration-500 ease-in-out hover:text-white hover:bg-gradient-to-r hover:from-[#a5c1e7] hover:to-[#dd99c1] hover:border-transparent hover:shadow-lg hover:scale-[1.04]"
-      @click="nextStep"
+      @click="step < steps.length - 1 ? nextStep() : submitHandler()"
     >
       {{ step < steps.length - 1 ? "下一題 ➡" : "完成並配對" }}
     </button>


### PR DESCRIPTION
finished #108 
- 實作問答流程的多步驟切換（ step 控制）
- 綁定引導小卡的篩選邏輯題目，每題的選取狀態（含多選與單選）
- MatchDoneModal.vue：點擊「傳送訊息」按鈕後，會呼叫 goToChatRoom() → 觸發 sendFriendMsg(targetId) 建立好友。
- useMatches.js：新增/呼叫 /matches API 發送 POST 請求，參數包含 targetId。
- 配對成功後會正確回傳 roomId、myProfile、targetProfile 給前端導向聊天室使用

**API 串接**
submitHandler() ：
POST /user-filter/interests → 傳送興趣 id 陣列（interestIds）
POST /user-filter/preference → 傳送配對條件（音樂、寵物、個性、作息、年齡區間）