### PR TITLE
優化首頁引導畫面

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -493,7 +493,7 @@ watch(route, () => {
                 : 'bg-white/10 hover:bg-white/20',
             ]"
           >
-            配對池
+            立即配對
           </LiquidNavLink>
 
           <LiquidNavLink
@@ -519,7 +519,7 @@ watch(route, () => {
                 : 'bg-white/10 hover:bg-white/20',
             ]"
           >
-            活動
+            探索活動
           </LiquidNavLink>
 
           <LiquidNavLink

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -16,10 +16,10 @@ const isDropdownOpen = ref(false);
 
 //定義每個區域的滾動位置
 const sectionPositions = {
-  about: 800, // 關於我們
-  tutorial: 2700, // 使用教學區
-  "activities-preview": 1700, // 探索活動
-  "match-preview": 3500, // 立即配對
+  about: 1000, // 關於我們
+  tutorial: 2800, // 使用教學區
+  "activities-preview": 1800, // 探索活動
+  "match-preview": 3600, // 立即配對
 };
 
 // 處理導覽點擊事件
@@ -391,7 +391,7 @@ watch(route, () => {
       ]"
     >
       <div class="space-y-2">
-        <!-- ✅ 未登入時：顯示首頁區域導覽按鈕 -->
+        <!-- 未登入時：顯示首頁區域導覽按鈕 -->
         <template v-if="!store.accessToken">
           <!-- 關於我們 -->
           <LiquidNavLink
@@ -481,7 +481,7 @@ watch(route, () => {
           </LiquidNavLink>
         </template>
 
-        <!-- ✅ 已登入時：顯示功能頁面連結 -->
+        <!-- 已登入時：顯示功能頁面連結 -->
         <template v-else>
           <LiquidNavLink
             to="/match"

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,23 +1,71 @@
 <script setup>
 import { ref, computed, watch } from "vue";
 import { useUserStore } from "@/stores/user";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import LiquidNavLink from "@/components/LiquidGlass.vue";
 import { useCartStore } from "@/stores/cart.js";
 import { useToast } from "vue-toastification";
 
 const route = useRoute();
+const router = useRouter();
 const store = useUserStore();
 const cartStore = useCartStore();
 const toast = useToast();
-
 const isMobileMenuOpen = ref(false);
 const isDropdownOpen = ref(false);
+
+//定義每個區域的滾動位置
+const sectionPositions = {
+  about: 800, // 關於我們
+  tutorial: 2700, // 使用教學區
+  "activities-preview": 1700, // 探索活動
+  "match-preview": 3500, // 立即配對
+};
+
+// 處理導覽點擊事件
+const handleNavClick = async (event, sectionId) => {
+  event.preventDefault();
+  if (route.path === "/") {
+    // 如果在首頁，滾動到對應位置
+    const targetPosition = sectionPositions[sectionId];
+    if (targetPosition) {
+      window.scrollTo({
+        top: targetPosition,
+        behavior: "smooth",
+      });
+    }
+  } else {
+    // 如果不在首頁，先跳轉到首頁
+    await router.push("/");
+
+    // 等待頁面載入完成，然後滾動
+    setTimeout(() => {
+      const targetPosition = sectionPositions[sectionId];
+      if (targetPosition) {
+        window.scrollTo({
+          top: targetPosition,
+          behavior: "smooth",
+        });
+      }
+    }, 300);
+  }
+
+  // 關閉手機選單
+  isMobileMenuOpen.value = false;
+};
+
+// 需要隱藏中間導覽按鈕的頁面
+const hideNavButtonsPages = ["/login", "/register"];
+
+// 判斷是否需要隱藏中間導覽按鈕
+const shouldHideNavButtons = computed(() =>
+  hideNavButtonsPages.includes(route.path)
+);
 
 // 判斷 header 是否滾動狀態
 const isScrolled = ref(false);
 window.addEventListener("scroll", () => {
-  isScrolled.value = window.scrollY > 10;
+  isScrolled.value = window.scrollY > 790;
 });
 
 // 白底頁面清單（可擴充）
@@ -109,26 +157,66 @@ watch(route, () => {
         </svg>
       </button>
 
-      <!-- 桌機導覽 - 1250px 以上顯示 -->
+      <!-- 桌機導覽 - 1250px 以上顯示 在登入註冊頁面時隱藏中間按鈕 -->
       <div
+        v-if="!shouldHideNavButtons"
         class="items-center justify-center flex-1 space-x-6 custom-desktop-show"
       >
-        <LiquidNavLink to="/match" :colorMode="getNavTextColor"
-          >配對池</LiquidNavLink
-        >
-        <LiquidNavLink to="/product" :colorMode="getNavTextColor"
-          >商品列表</LiquidNavLink
-        >
-        <LiquidNavLink to="/activities" :colorMode="getNavTextColor"
-          >活動</LiquidNavLink
-        >
-        <LiquidNavLink to="/activities/new" :colorMode="getNavTextColor"
-          >活動表單</LiquidNavLink
-        >
-        <LiquidNavLink to="/activities/my" :colorMode="getNavTextColor"
-          >我的活動</LiquidNavLink
-        >
+        <template v-if="!store.accessToken">
+          <!-- 保留 LiquidNavLink 樣式，但加入點擊事件處理 -->
+          <LiquidNavLink
+            to=""
+            :colorMode="getNavTextColor"
+            @click="(e) => handleNavClick(e, 'about')"
+          >
+            關於我們
+          </LiquidNavLink>
+
+          <LiquidNavLink
+            to=""
+            :colorMode="getNavTextColor"
+            @click="(e) => handleNavClick(e, 'activities-preview')"
+          >
+            探索活動
+          </LiquidNavLink>
+
+          <LiquidNavLink
+            to=""
+            :colorMode="getNavTextColor"
+            @click="(e) => handleNavClick(e, 'tutorial')"
+          >
+            使用教學
+          </LiquidNavLink>
+
+          <LiquidNavLink
+            to=""
+            :colorMode="getNavTextColor"
+            @click="(e) => handleNavClick(e, 'match-preview')"
+          >
+            立即配對
+          </LiquidNavLink>
+        </template>
+        <template v-else>
+          <LiquidNavLink to="/match" :colorMode="getNavTextColor"
+            >立即配對</LiquidNavLink
+          >
+          <LiquidNavLink to="/product" :colorMode="getNavTextColor"
+            >商品列表</LiquidNavLink
+          >
+          <LiquidNavLink to="/activities/new" :colorMode="getNavTextColor"
+            >活動表單</LiquidNavLink
+          >
+          <LiquidNavLink to="/activities/my" :colorMode="getNavTextColor"
+            >我的活動</LiquidNavLink
+          >
+          <LiquidNavLink to="/activities" :colorMode="getNavTextColor"
+            >探索活動</LiquidNavLink
+          >
+        </template>
       </div>
+
+      <!-- 如果隱藏中間按鈕，用空的 div 保持佈局 -->
+      <div v-else class="flex-1 custom-desktop-show"></div>
 
       <!-- 使用者選單 - 1250px 以上顯示 -->
       <div class="items-center justify-end space-x-4 custom-desktop-show">

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -5,7 +5,7 @@ import { useRoute } from "vue-router";
 import LiquidNavLink from "@/components/LiquidGlass.vue";
 import { useCartStore } from "@/stores/cart.js";
 import { useToast } from "vue-toastification";
-import ScrollToTop from "@/components/ScrollToTop.vue"
+import ScrollToTop from "@/components/ScrollToTop.vue";
 
 const route = useRoute();
 const store = useUserStore();
@@ -391,69 +391,69 @@ watch(route, () => {
       ]"
     >
       <div class="space-y-2">
-        <LiquidNavLink
-          to="/match"
-          :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
-          class="block !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
-          :class="[
-            isScrolled || isLightBgPage
-              ? 'bg-white/80 hover:bg-white hover:shadow-sm'
-              : 'bg-white/10 hover:bg-white/20',
-          ]"
-        >
-          配對池
-        </LiquidNavLink>
-        <LiquidNavLink
-          to="/product"
-          :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
-          class="block !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
-          :class="[
-            isScrolled || isLightBgPage
-              ? 'bg-white/80 hover:bg-white hover:shadow-sm'
-              : 'bg-white/10 hover:bg-white/20',
-          ]"
-        >
-          商品列表
-        </LiquidNavLink>
-        <LiquidNavLink
-          to="/activities"
-          :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
-          class="block !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
-          :class="[
-            isScrolled || isLightBgPage
-              ? 'bg-white/80 hover:bg-white hover:shadow-sm'
-              : 'bg-white/10 hover:bg-white/20',
-          ]"
-        >
-          活動
-        </LiquidNavLink>
-        <LiquidNavLink
-          to="/activities/new"
-          :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
-          class="block !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
-          :class="[
-            isScrolled || isLightBgPage
-              ? 'bg-white/80 hover:bg-white hover:shadow-sm'
-              : 'bg-white/10 hover:bg-white/20',
-          ]"
-        >
-          活動表單
-        </LiquidNavLink>
-
-        <LiquidNavLink
-          to="/activities/my"
-          :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
-          class="block !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
-          :class="[
-            isScrolled || isLightBgPage
-              ? 'bg-white/80 hover:bg-white hover:shadow-sm'
-              : 'bg-white/10 hover:bg-white/20',
-          ]"
-        >
-          我的活動
-        </LiquidNavLink>
-
+        <!-- ✅ 未登入時：顯示首頁區域導覽按鈕 -->
         <template v-if="!store.accessToken">
+          <!-- 關於我們 -->
+          <LiquidNavLink
+          to="#"
+          :colorMode="getNavTextColor"
+            @click="(e) => handleNavClick(e, 'about')"
+            class="block w-full !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
+            :class="[
+              isScrolled || isLightBgPage
+                ? 'bg-white/80 hover:bg-white hover:shadow-sm text-black'
+                : 'bg-white/10 hover:bg-white/20 text-white',
+            ]"
+          >
+            關於我們
+          </LiquidNavLink>
+
+          <!-- 探索活動 -->
+          <LiquidNavLink
+          to="#"
+          :colorMode="getNavTextColor"
+            @click="(e) => handleNavClick(e, 'activities-preview')"
+            class="block w-full !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
+            :class="[
+              isScrolled || isLightBgPage
+                ? 'bg-white/80 hover:bg-white hover:shadow-sm text-black'
+                : 'bg-white/10 hover:bg-white/20 text-white',
+            ]"
+          >
+            探索活動
+          </LiquidNavLink>
+
+          <!-- 使用教學 -->
+          <LiquidNavLink
+            to="#"
+            :colorMode="getNavTextColor"
+            @click="(e) => handleNavClick(e, 'tutorial')"
+            class="block w-full !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
+            :class="[
+              isScrolled || isLightBgPage
+                ? 'bg-white/80 hover:bg-white hover:shadow-sm text-black'
+                : 'bg-white/10 hover:bg-white/20 text-white',
+            ]"
+          >
+            使用教學
+          </LiquidNavLink>
+
+          <!-- 立即配對 -->
+          <LiquidNavLink
+            to="#"
+            :colorMode="getNavTextColor"
+            @click="(e) => handleNavClick(e, 'match-preview')"
+            class="block w-full !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
+            :class="[
+              isScrolled || isLightBgPage
+                ? 'bg-white/80 hover:bg-white hover:shadow-sm text-black'
+                : 'bg-white/10 hover:bg-white/20 text-white',
+            ]"
+          >
+            立即配對
+          </LiquidNavLink>
+
+          <!-- 登入/註冊按鈕 -->
           <LiquidNavLink
             to="/login"
             :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
@@ -466,6 +466,7 @@ watch(route, () => {
           >
             登入
           </LiquidNavLink>
+
           <LiquidNavLink
             to="/register"
             :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
@@ -479,7 +480,74 @@ watch(route, () => {
             註冊
           </LiquidNavLink>
         </template>
+
+        <!-- ✅ 已登入時：顯示功能頁面連結 -->
         <template v-else>
+          <LiquidNavLink
+            to="/match"
+            :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
+            class="block !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
+            :class="[
+              isScrolled || isLightBgPage
+                ? 'bg-white/80 hover:bg-white hover:shadow-sm'
+                : 'bg-white/10 hover:bg-white/20',
+            ]"
+          >
+            配對池
+          </LiquidNavLink>
+
+          <LiquidNavLink
+            to="/product"
+            :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
+            class="block !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
+            :class="[
+              isScrolled || isLightBgPage
+                ? 'bg-white/80 hover:bg-white hover:shadow-sm'
+                : 'bg-white/10 hover:bg-white/20',
+            ]"
+          >
+            商品列表
+          </LiquidNavLink>
+
+          <LiquidNavLink
+            to="/activities"
+            :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
+            class="block !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
+            :class="[
+              isScrolled || isLightBgPage
+                ? 'bg-white/80 hover:bg-white hover:shadow-sm'
+                : 'bg-white/10 hover:bg-white/20',
+            ]"
+          >
+            活動
+          </LiquidNavLink>
+
+          <LiquidNavLink
+            to="/activities/new"
+            :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
+            class="block !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
+            :class="[
+              isScrolled || isLightBgPage
+                ? 'bg-white/80 hover:bg-white hover:shadow-sm'
+                : 'bg-white/10 hover:bg-white/20',
+            ]"
+          >
+            活動表單
+          </LiquidNavLink>
+
+          <LiquidNavLink
+            to="/activities/my"
+            :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
+            class="block !px-3 py-2 !text-[16px] overflow-hidden text-ellipsis whitespace-nowrap font-medium text-right transition-all duration-200 rounded-xl"
+            :class="[
+              isScrolled || isLightBgPage
+                ? 'bg-white/80 hover:bg-white hover:shadow-sm'
+                : 'bg-white/10 hover:bg-white/20',
+            ]"
+          >
+            我的活動
+          </LiquidNavLink>
+
           <LiquidNavLink
             to="/chat"
             :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
@@ -492,6 +560,7 @@ watch(route, () => {
           >
             訊息
           </LiquidNavLink>
+
           <LiquidNavLink
             to="/cart"
             :colorMode="isScrolled || isLightBgPage ? 'black' : 'white'"
@@ -561,9 +630,8 @@ watch(route, () => {
         </template>
       </div>
     </div>
-    
   </header>
-   <ScrollToTop />
+  <ScrollToTop />
 </template>
 
 <style scoped>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,13 +1,13 @@
 <script setup>
 import { ref, computed, watch } from "vue";
 import { useUserStore } from "@/stores/user";
-import { useRoute, useRouter } from "vue-router";
+import { useRoute } from "vue-router";
 import LiquidNavLink from "@/components/LiquidGlass.vue";
 import { useCartStore } from "@/stores/cart.js";
 import { useToast } from "vue-toastification";
+import ScrollToTop from "@/components/ScrollToTop.vue"
 
 const route = useRoute();
-const router = useRouter();
 const store = useUserStore();
 const cartStore = useCartStore();
 const toast = useToast();
@@ -561,7 +561,9 @@ watch(route, () => {
         </template>
       </div>
     </div>
+    
   </header>
+   <ScrollToTop />
 </template>
 
 <style scoped>

--- a/src/components/ScrollToTop.vue
+++ b/src/components/ScrollToTop.vue
@@ -1,0 +1,78 @@
+<template>
+  <Transition name="fade">
+    <button
+      v-if="showButton"
+      @click="scrollToTop"
+      class="fixed bottom-6 right-6 z-50 flex items-center justify-center w-12 h-12 sm:w-14 sm:h-14 rounded-full shadow-lg transition-all duration-300 hover:scale-110 hover:shadow-xl bg-gradient-to-r bg-[#229EBC] hover:bg-[#1a7a94]"
+      aria-label="返回頂部"
+    >
+      <!-- 箭頭向上圖標 -->
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="w-5 h-5 sm:w-6 sm:h-6 text-white"
+      >
+        <path d="m18 15-6-6-6 6"/>
+      </svg>
+    </button>
+  </Transition>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+
+// 控制按鈕顯示
+const showButton = ref(false)
+
+// 檢查滾動位置
+const checkScroll = () => {
+  showButton.value = window.scrollY > 300 // 滾動超過 300px 時顯示
+}
+
+// 滾動到頂部
+const scrollToTop = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth'
+  })
+}
+
+// 生命週期
+onMounted(() => {
+  window.addEventListener('scroll', checkScroll)
+  checkScroll() // 初始檢查
+})
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', checkScroll)
+})
+</script>
+
+<style scoped>
+/* 淡入淡出動畫 */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.fade-enter-from {
+  opacity: 0;
+  transform: translateY(20px) scale(0.8);
+}
+
+.fade-leave-to {
+  opacity: 0;
+  transform: translateY(20px) scale(0.8);
+}
+
+.fade-enter-to,
+.fade-leave-from {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+</style>


### PR DESCRIPTION
Close https://github.com/Kizuna-team/frontend/issues/145
Close https://github.com/Kizuna-team/frontend/issues/136

修改:
活動改為→探索活動
配對池改為→立即配對

未登入會顯示:[關於我們][探索活動][使用教學][立即配對] 點擊後會滑到對應的位子
**加入捲動到頂部的按鈕**

https://github.com/user-attachments/assets/b0ea54a2-abb9-43d9-8871-9d8a98dfc754


登入後會顯示其他按鈕
在登入跟註冊頁面隱藏[關於我們][探索活動][使用教學][立即配對]按鈕

https://github.com/user-attachments/assets/8964f1d1-95f0-4d30-8e64-cf9e7bd0fb9f

RWD(登入後其餘沒變)

![image](https://github.com/user-attachments/assets/18b598f3-4497-4ba5-9cc6-e1ebaf440b43)

