### PR TITLE
[ 修復 BUG ] 即時登入狀態 還是會跳回登入頁

### DIFF
--- a/src/components/MemberShowcase.vue
+++ b/src/components/MemberShowcase.vue
@@ -1,6 +1,11 @@
 <script setup>
+import { useRouter } from 'vue-router';
+import { useUserStore } from '@/stores/user';
 import MemberCard from "./MemberCard.vue";
 
+
+const router = useRouter();
+const userStore = useUserStore();
 const animationDuration = 40;
 
 const members = [
@@ -13,6 +18,14 @@ const members = [
   { photo: "/people.jpg", firstName: "Mike", lastName: "Huang" },
   { photo: "/people.jpg", firstName: "Sandy", lastName: "Liu" },
 ];
+
+const handleClick = () => {
+  if(userStore.isLoggedIn){
+    router.push('/match/setup');
+  }else{
+    router.push('/register');
+  }
+};
 </script>
 
 <template>
@@ -50,15 +63,14 @@ const members = [
         </div>
       </div>
       <div class="mt-20">
-        <router-link to="/register">
           <button
+            @click.prevent="handleClick"
             type="button"
             class="py-[18px] text-2xl font-bold text-white transition-all duration-300 origin-center rounded-full shadow-xl w-80 bg-gradient-to-r from-secondary to-pink-500 hover:scale-110 hover:brightness-110 hover:animate-pulse"
           >
             立即開始配對<br />
             <span class="text-xl font-normal">Let’s Match!</span>
           </button>
-        </router-link>
       </div>
     </div>
   </section>

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -1,6 +1,6 @@
 import axios from "../api/axios";
 import { defineStore } from "pinia";
-import { ref, reactive } from "vue";
+import { ref, reactive, computed } from "vue";
 
 export const useUserStore = defineStore("user", () => {
 
@@ -29,6 +29,8 @@ export const useUserStore = defineStore("user", () => {
     profile.bio = profileDate.bio;
     profile.interests = profileDate.interests;
   }
+
+  const isLoggedIn = computed( () => !!accessToken.value);
 
   const register = async (usernameInput, passwordInput) => {
     try {
@@ -145,6 +147,7 @@ export const useUserStore = defineStore("user", () => {
     username,
     userId,
     profile,
+    isLoggedIn,
     getProfile,
     register,
     login,


### PR DESCRIPTION
close #177 
修復老師發現的 BUG 
按下 首頁中 “立即開始配對” 按鈕 會判斷 ( Pinia ) `user.js`

如果 有登入 拿到token 就跳到配對小卡
否則 跳到註冊頁面

```javascript
const handleClick = () => {
  if(userStore.isLoggedIn){
    router.push('/match/setup');
  }else{
    router.push('/register');
  }
};
``` 
```html
<button
     @click.prevent="handleClick"
     type="button"
     class="py-[18px] text-2xl font-bold text-white transition-all duration-300 origin-center rounded-full shadow-xl w-80 bg-gradient-to-r from-secondary to-pink-500 hover:scale-110 hover:brightness-110 hover:animate-pulse">
        立即開始配對<br />
        <span class="text-xl font-normal">Let’s Match!</span>
</button>
```