### PR TITLE
修復活動頁面誤判活動不存在的問題

### DIFF
--- a/src/views/EventCardByIdView.vue
+++ b/src/views/EventCardByIdView.vue
@@ -2,67 +2,39 @@
 import { useRoute } from "vue-router";
 import { onMounted, ref } from "vue";
 import { useActivityStore } from "@/stores/activity";
+import { useUserStore } from "@/stores/user";
 import { storeToRefs } from "pinia";
 import axios from "../api/axios.js";
-import { useToast } from 'vue-toastification'
-import { 
-  ArrowLeftIcon, 
-  UserIcon, 
-  ClockIcon, 
-  MapPinIcon, 
-  UsersIcon, 
+import { useToast } from "vue-toastification";
+import { useRouter } from "vue-router";
+import {
+  ArrowLeftIcon,
+  UserIcon,
+  ClockIcon,
+  MapPinIcon,
+  UsersIcon,
   CalendarIcon,
   ShareIcon,
   ClipboardDocumentIcon,
-  PhotoIcon
-} from '@heroicons/vue/24/outline'
+  PhotoIcon,
+} from "@heroicons/vue/24/outline";
 
 const route = useRoute();
+const router = useRouter();
 const store = useActivityStore();
+const userStore = useUserStore();
 const { fetchActivityById } = store;
 const { selectedActivity, loading } = storeToRefs(store);
-const toast = useToast()
+const { isLoggedIn } = storeToRefs(userStore);
+const toast = useToast();
 const showShareMenu = ref(false);
-const activityStatus = ref('');
-
-const fetchActivityStatus = async () => {
-  const userId = localStorage.getItem("userId");
-  const activityId = route.params.id;
-
-  if (!userId || !activityId) return;
-
-  try {
-    const res = await axios.post(`/activities/status`, {
-      userId,
-      activityIds: [Number(activityId)], // 只查詢當前活動
-    });
-
-    if (res.data.statuses && res.data.statuses.length > 0) {
-      activityStatus.value = res.data.statuses[0].status;
-    }
-  } catch (err) {
-    console.error("查詢活動狀態失敗", err);
-  }
-};
 
 const handleJoin = async () => {
-  const activityId = Number(route.params.id);
-  const previousStatus = activityStatus.value;
-  activityStatus.value = "ALREADY_JOINED";
-  if (selectedActivity.value) {
-    selectedActivity.value.current_participants = Number(selectedActivity.value.current_participants) + 1;
-  }
-
   try {
-    const res = await axios.post(`/activities/join/${activityId}`);
+    const res = await axios.post(`/activities/join/${route.params.id}`);
     toast.success(res.data.message);
+    await fetchActivityById(route.params.id);
   } catch (err) {
-    // 失敗時恢復
-    activityStatus.value = previousStatus;
-    if (selectedActivity.value) {
-      selectedActivity.value.current_participants = Number(selectedActivity.value.current_participants) - 1;
-    }
-    
     if (err.response?.status === 409) {
       toast.error(err.response.data.message);
     } else {
@@ -79,17 +51,16 @@ const copyLink = async () => {
   try {
     const url = window.location.href;
     await navigator.clipboard.writeText(url);
-    toast.success('連結已複製到剪貼簿！');
+    toast.success("連結已複製到剪貼簿！");
     showShareMenu.value = false;
   } catch (err) {
-    // 如果瀏覽器不支援 clipboard API，用舊方法
-    const textArea = document.createElement('textarea');
+    const textArea = document.createElement("textarea");
     textArea.value = window.location.href;
     document.body.appendChild(textArea);
     textArea.select();
-    document.execCommand('copy');
+    document.execCommand("copy");
     document.body.removeChild(textArea);
-    toast.success('連結已複製到剪貼簿！');
+    toast.success("連結已複製到剪貼簿！");
     showShareMenu.value = false;
   }
 };
@@ -97,40 +68,45 @@ const copyLink = async () => {
 const shareToLine = () => {
   const url = window.location.href;
   const text = `${selectedActivity.value.title} - ${selectedActivity.value.description}`;
-  const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`;
-  window.open(lineUrl, '_blank');
+  const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(
+    url
+  )}&text=${encodeURIComponent(text)}`;
+  window.open(lineUrl, "_blank");
   showShareMenu.value = false;
 };
 
 const shareToFacebook = () => {
   const url = window.location.href;
-  const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
-  window.open(facebookUrl, '_blank');
+  const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(
+    url
+  )}`;
+  window.open(facebookUrl, "_blank");
   showShareMenu.value = false;
 };
 
 const handleClickOutside = (event) => {
-  if (!event.target.closest('.relative')) {
+  if (!event.target.closest(".relative")) {
     showShareMenu.value = false;
   }
 };
 
 onMounted(async () => {
   await fetchActivityById(route.params.id);
-  await fetchActivityStatus();
-  document.addEventListener('click', handleClickOutside);
+  document.addEventListener("click", handleClickOutside);
 });
 </script>
 
 <template>
   <div class="min-h-screen bg-gray-50">
     <div v-if="loading" class="flex items-center justify-center min-h-screen">
-      <div class="w-8 h-8 border-4 border-blue-500 rounded-full border-t-transparent animate-spin"></div>
+      <div
+        class="w-8 h-8 border-4 border-blue-500 rounded-full border-t-transparent animate-spin"
+      ></div>
     </div>
 
     <div v-else-if="selectedActivity" class="max-w-4xl mx-auto">
       <div class="p-4">
-        <button 
+        <button
           @click="$router.push('/activities')"
           class="flex items-center text-gray-600 transition-colors hover:text-gray-800"
         >
@@ -141,13 +117,16 @@ onMounted(async () => {
 
       <div class="mx-4 mb-8 overflow-hidden bg-white shadow-sm rounded-2xl">
         <div class="relative">
-          <img 
-            v-if="selectedActivity.image_url" 
-            :src="selectedActivity.image_url" 
+          <img
+            v-if="selectedActivity.image_url"
+            :src="selectedActivity.image_url"
             :alt="selectedActivity.title"
             class="object-cover w-full h-64 md:h-80"
           />
-          <div v-else class="flex items-center justify-center w-full h-64 md:h-80 bg-gradient-to-br from-blue-400 to-purple-500">
+          <div
+            v-else
+            class="flex items-center justify-center w-full h-64 md:h-80 bg-gradient-to-br from-blue-400 to-purple-500"
+          >
             <PhotoIcon class="w-16 h-16 text-white opacity-50" />
           </div>
         </div>
@@ -168,9 +147,7 @@ onMounted(async () => {
               <ClockIcon class="w-5 h-5 mr-3 mt-0.5 text-blue-500" />
               <div>
                 <div class="font-medium text-gray-900">活動時間</div>
-                <div class="text-gray-600">
-                  {{ selectedActivity.date }}
-                </div>
+                <div class="text-gray-600">{{ selectedActivity.date }}</div>
               </div>
             </div>
 
@@ -188,15 +165,19 @@ onMounted(async () => {
                 <div class="font-medium text-gray-900">參加人數</div>
                 <div class="flex items-center">
                   <span class="text-gray-600">
-                    {{ selectedActivity.current_participants }} / {{ selectedActivity.max_participants }}
+                    {{ selectedActivity.current_participants }} /
+                    {{ selectedActivity.max_participants }}
                   </span>
-                  <span 
-                    v-if="Number(selectedActivity.current_participants) >= selectedActivity.max_participants"
+                  <span
+                    v-if="
+                      Number(selectedActivity.current_participants) >=
+                      selectedActivity.max_participants
+                    "
                     class="px-2 py-1 ml-2 text-xs text-red-600 bg-red-100 rounded-full"
                   >
                     已額滿
                   </span>
-                  <span 
+                  <span
                     v-else
                     class="px-2 py-1 ml-2 text-xs text-green-600 bg-green-100 rounded-full"
                   >
@@ -210,7 +191,9 @@ onMounted(async () => {
               <CalendarIcon class="w-5 h-5 mr-3 mt-0.5 text-purple-500" />
               <div>
                 <div class="font-medium text-gray-900">創建時間</div>
-                <div class="text-gray-600">{{ selectedActivity.created_at }}</div>
+                <div class="text-gray-600">
+                  {{ selectedActivity.created_at }}
+                </div>
               </div>
             </div>
           </div>
@@ -223,63 +206,70 @@ onMounted(async () => {
           </div>
 
           <div class="flex flex-col gap-3 sm:flex-row">
-            <button 
-              v-if="activityStatus === 'OPEN'"
+            <button
+              v-if="!isLoggedIn"
+              @click="router.push('/login')"
+              class="flex-1 px-6 py-3 font-medium text-white transition-colors bg-gray-600 hover:bg-gray-700 rounded-xl"
+            >
+              請先登入
+            </button>
+
+            <button
+              v-else-if="
+                Number(selectedActivity.current_participants) <
+                selectedActivity.max_participants
+              "
               @click="handleJoin"
               class="flex-1 px-6 py-3 font-medium text-white transition-colors bg-blue-600 hover:bg-blue-700 rounded-xl"
             >
               加入活動
             </button>
-            
-            <button 
-              v-else-if="activityStatus === 'ALREADY_JOINED'"
-              disabled
-              class="flex-1 px-6 py-3 font-medium text-gray-400 border-2 border-gray-400 cursor-not-allowed rounded-xl"
-            >
-              已加入
-            </button>
-            
-            <button 
-              v-else-if="activityStatus === 'FULL'"
+
+            <button
+              v-else
               disabled
               class="flex-1 px-6 py-3 font-medium text-red-400 border-2 border-red-400 cursor-not-allowed rounded-xl"
             >
               已額滿
             </button>
 
-            <button 
+            <button
               @click="handleShare"
               class="relative px-6 py-3 font-medium text-gray-700 transition-colors bg-gray-100 hover:bg-gray-200 rounded-xl"
             >
               <ShareIcon class="w-5 h-5 mx-auto" />
-              
-              <div 
+
+              <div
                 v-if="showShareMenu"
                 class="absolute right-0 z-10 p-2 mb-2 bg-white border border-gray-200 rounded-lg shadow-lg bottom-full min-w-48"
               >
-                <button 
+                <button
                   @click="copyLink"
                   class="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-md hover:bg-gray-100"
                 >
                   <ClipboardDocumentIcon class="w-4 h-4 mr-2" />
                   複製連結
                 </button>
-                
-                <button 
+
+                <button
                   @click="shareToLine"
                   class="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-md hover:bg-gray-100"
                 >
-                  <div class="flex items-center justify-center w-4 h-4 mr-2 bg-green-500 rounded-sm">
+                  <div
+                    class="flex items-center justify-center w-4 h-4 mr-2 bg-green-500 rounded-sm"
+                  >
                     <span class="text-xs font-bold text-white">L</span>
                   </div>
                   分享到 LINE
                 </button>
-                
-                <button 
+
+                <button
                   @click="shareToFacebook"
                   class="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-md hover:bg-gray-100"
                 >
-                  <div class="flex items-center justify-center w-4 h-4 mr-2 bg-blue-600 rounded-sm">
+                  <div
+                    class="flex items-center justify-center w-4 h-4 mr-2 bg-blue-600 rounded-sm"
+                  >
                     <span class="text-xs font-bold text-white">f</span>
                   </div>
                   分享到 Facebook
@@ -291,12 +281,28 @@ onMounted(async () => {
       </div>
     </div>
 
-    <div v-else class="flex flex-col items-center justify-center min-h-screen text-gray-500">
-      <svg class="w-16 h-16 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 12h6m-6-4h6m2 5.291A7.962 7.962 0 0112 15c-2.34 0-4.441-1.01-5.903-2.62l.15.291a7.962 7.962 0 0002.13 1.83C9.17 14.24 10.542 14.5 12 14.5c1.458 0 2.83-.26 3.62-.92a7.962 7.962 0 002.13-1.83l.15-.291C16.441 14.01 14.34 15 12 15s-4.441-1.01-5.903-2.62zM21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    <div
+      v-else
+      class="flex flex-col items-center justify-center min-h-screen text-gray-500"
+    >
+      <svg
+        class="w-16 h-16 mb-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M9.172 16.172a4 4 0 015.656 0M9 12h6m-6-4h6m2 5.291A7.962 7.962 0 0112 15c-2.34 0-4.441-1.01-5.903-2.62l.15.291a7.962 7.962 0 0002.13 1.83C9.17 14.24 10.542 14.5 12 14.5c1.458 0 2.83-.26 3.62-.92a7.962 7.962 0 002.13-1.83l.15-.291C16.441 14.01 14.34 15 12 15s-4.441-1.01-5.903-2.62zM21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
       </svg>
       <p class="text-xl">活動不存在或已被刪除</p>
-      <button @click="$router.push('/activities')" class="mt-4 text-blue-600 hover:text-blue-800">
+      <button
+        @click="$router.push('/activities')"
+        class="mt-4 text-blue-600 hover:text-blue-800"
+      >
         返回活動列表
       </button>
     </div>


### PR DESCRIPTION
因為有做分享連結的按鈕
原本直接點進活動連結會顯示活動不存在的問題
是因為未登入沒拿到活動ID 導致誤判活動不存在

現在後端有做修改
並在前端新增登入判斷
如果沒登入
按鈕會顯示請先登入
點擊後跳轉到登入頁面

![image](https://github.com/user-attachments/assets/89ea5a17-008c-4b2d-9f1f-d696059dfbc4)
