### PR TITLE
[ 頁面優化調整 ] 頁面路徑、按鈕Hover填滿

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -93,13 +93,13 @@ const router = createRouter({
     },
     {
       path: "/match",
-      name: "Match",
-      component: MatchView,
-    },
-    {
-      path: "/match/setup",
       name: "MatchSetup",
       component: MatchSetupView,
+    },
+    {
+      path: "/match/result",
+      name: "MatchResult",
+      component: MatchView,
     },
     {
       path: "/order/confirm",

--- a/src/views/MatchSetupView.vue
+++ b/src/views/MatchSetupView.vue
@@ -184,7 +184,7 @@ const submitHandler = async () => {
 
     isSetting.value = true;
     setTimeout(() => {
-      router.push("/match");
+      router.push("/match/result");
       isSetting.value = false;
     }, 800);
   } catch (err) {

--- a/src/views/MatchSetupView.vue
+++ b/src/views/MatchSetupView.vue
@@ -256,7 +256,7 @@ const submitHandler = async () => {
     </div>
 
     <button
-      class="px-6 py-3 md:px-8 md:py-3 rounded-full font-bold tracking-wide text-[#a5c1e7] border-[3px] border-[#a5c1e7] bg-white transition-all duration-500 ease-in-out hover:text-white hover:bg-gradient-to-r hover:from-[#a5c1e7] hover:to-[#dd99c1] hover:border-transparent hover:shadow-lg hover:scale-[1.04] text-sm md:text-base"
+      class="px-6 py-3 md:px-8 md:py-3 rounded-full font-bold tracking-wide border-[3px] border-[#a5c1e7] text-[#a5c1e7] text-sm md:text-base transition-all duration-300 ease-in-out bg-white hover:text-white hover:bg-gradient-to-r hover:from-[#a5c1e7] hover:to-[#dd99c1] hover:border-transparent hover:shadow-lg hover:scale-[1.04] hover:bg-origin-border hover:bg-clip-padding"
       @click="step < steps.length - 1 ? nextStep() : submitHandler()"
     >
       {{ step < steps.length - 1 ? "下一題" : "完成並配對" }}


### PR DESCRIPTION
**修改： 立即配對 ⇨ 引導小卡 ⇨ 配對池**

<img width="275" alt="image" src="https://github.com/user-attachments/assets/228611f8-09a0-41ac-8a88-d70747a5ce0f" />

@sin-huang 
導引頁面跳哪 你決定我沒意見
啊如果你覺得現在編輯完照片後，跳導引頁面很怪我就拿掉，跳首頁
－－－
按鈕 `hover` 填滿

https://github.com/user-attachments/assets/2d68fa19-e116-49db-967d-d95a79c65e96

